### PR TITLE
環境変数`ROBOT_NAME`をherokuに設定しないでbotの名前を変更する

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ROBOT_NAME=riety

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-bot: bundle exec ruboty -l init.rb
+bot: bundle exec ruboty --dotenv -l init.rb

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Riety is ruboty bot.
 ```
 # After clone this repository
 % bundle install
-% bundle exec ruboty -l init.rb
+% bundle exec ruboty -l init.rb --dotenv
 Type `exit` or `quit` to end the session.
-> ruboty help
-ruboty /hello/ - greet
-ruboty /help( me)?(?: (?<filter>.+))?\z/i - Show this help message
-ruboty /ping\z/i - Return PONG to PING
-ruboty /who am i\?/i - Answer who you are
+> riety help
+riety /hello/ - greet
+riety /help( me)?(?: (?<filter>.+))?\z/i - Show this help message
+riety /ping\z/i - Return PONG to PING
+riety /who am i\?/i - Answer who you are
 ```
 
 # Test
@@ -32,7 +32,6 @@ Execute `test_*.rb` files in `test` dir.
 ```
 # Using heroku
 % heroku config:set IDOBATA_API_TOKEN=foobar
-% heroku config:set ROBOT_NAME=riety
 % heroku create
 % git push heroku master
 ```


### PR DESCRIPTION
Rubotyのbot名を変更するには、環境変数に`ROBOT_NAME=hoge`とする必要があります。
`dotenv`を使うことで、面倒なherokuの環境変数の設定を減らしました。
dev環境だとこっちの方が雰囲気出そう。

idobataのtokenを公開するのは良くないので、`IDOBATA_API_TOKEN`はこのままにします。
