### PR TITLE
集合写真表示 [closes #4]

### DIFF
--- a/lib/riety/handlers/group_photo.rb
+++ b/lib/riety/handlers/group_photo.rb
@@ -1,0 +1,17 @@
+module Riety
+  module Handlers
+    class GroupPhoto < Ruboty::Handlers::Base
+      on /group photo/, name: 'group_photo', description: 'Display group photo at random'
+
+      def group_photo(message)
+        message.reply photo_urls.sample
+      end
+
+      private
+
+        def photo_urls
+          ['http://magazine.rubyist.net/?c=plugin;plugin=attach_download;p=0050-YochiyochiRbLtEventReport;file_name=Gathering.JPG']
+        end
+    end
+  end
+end

--- a/test/handlers/test_group_photo.rb
+++ b/test/handlers/test_group_photo.rb
@@ -1,0 +1,14 @@
+require './test/test_helper'
+
+class GroupPhotoTest < Minitest::Test
+  def setup
+    @bot = ::Ruboty::Robot.new
+    @to = '#general'
+    @from = 'alice'
+    @said = '@ruboty group photo'
+  end
+
+  def test_gruop_photo_return_image_url
+    assert_output(/^https?:\/\/.+\.(jpg|gif|png)$/i) { @bot.receive body: @said, from: @from, to: @to }
+  end
+end


### PR DESCRIPTION
http://magazine.rubyist.net/?0050-YochiyochiRbLtEventReport の記事の最後の集合写真のURLを表示するようにしました。idobataがよろしく解釈して画像を出してくれる、、はず
## Issue

connects to https://github.com/suburi/riety/issues/4
