### PR TITLE
shiritori コマンドを `しりとり` という平仮名表記でも実行したい

### DIFF
--- a/lib/riety/handlers/shiritori.rb
+++ b/lib/riety/handlers/shiritori.rb
@@ -3,7 +3,7 @@ require 'yaml'
 module Riety
   module Handlers
     class Shiritori < Ruboty::Handlers::Base
-      on /shiritori/, name: 'shiritori', description: "しりとり (例: #{ENV['ROBOT_NAME']} shiritori うみほたる)"
+      on /shiritori|しりとり/, name: 'shiritori', description: "しりとり (例: #{ENV['ROBOT_NAME']} shiritori うみほたる、#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
 
       def shiritori(message)
         word = words[message.body[-1]]

--- a/lib/riety/handlers/shiritori.rb
+++ b/lib/riety/handlers/shiritori.rb
@@ -3,7 +3,7 @@ require 'yaml'
 module Riety
   module Handlers
     class Shiritori < Ruboty::Handlers::Base
-      on /shiritori|しりとり/, name: 'shiritori', description: "しりとり (例: #{ENV['ROBOT_NAME']} shiritori うみほたる、#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
+      on /shiritori|しりとり/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
 
       def shiritori(message)
         word = words[message.body[-1]]

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -8,18 +8,22 @@ class ShiritoriTest < Minitest::Test
   end
 
   def test_shiritori_should_return_expected_reply_which_ends_shiritori
-    @said = '@ruboty shiritori ...あ'
-    assert_output(/^アサーション$/) { @bot.receive body: @said, from: @from, to: @to }
-    @said = '@ruboty shiritori ...わ'
-    assert_output(/^ワッペン$/) { @bot.receive body: @said, from: @from, to: @to }
+    %w[shiritori しりとり].each do |command|
+      @said = "@ruboty #{command} ...あ"
+      assert_output(/^アサーション$/) { @bot.receive body: @said, from: @from, to: @to }
+      @said = "@ruboty #{command} ...わ"
+      assert_output(/^ワッペン$/) { @bot.receive body: @said, from: @from, to: @to }
+    end
   end
 
   def test_shiritori_cannot_understand_non_hiragana_word
-    @said = '@ruboty shiritori ...a'
-    assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
-    @said = '@ruboty shiritori ...1'
-    assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
-    @said = '@ruboty shiritori ...亜'
-    assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
+    %w[shiritori しりとり].each do |command|
+      @said = "@ruboty #{command} ...a"
+      assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
+      @said = "@ruboty #{command} ...1"
+      assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
+      @said = "@ruboty #{command} ...亜"
+      assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
+    end
   end
 end


### PR DESCRIPTION
ひらがなでも実行できるようにしました

<img width="302" alt="2015-11-28 17 55 56" src="https://cloud.githubusercontent.com/assets/1925244/11451028/6b305c3c-95f9-11e5-8538-f7f5700ca365.png">
## Issue

https://github.com/suburi/riety/issues/17
