### PR TITLE
shiritoriコマンドで対象ワードがないときメッセージを表示するようにしました

### DIFF
--- a/lib/riety/handlers/shiritori.rb
+++ b/lib/riety/handlers/shiritori.rb
@@ -6,6 +6,10 @@ module Riety
       on /shiritori|しりとり/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
 
       def shiritori(message)
+        if message.body.split(/\s|　/).count == 2
+          return message.reply 'なんか言ってくれないとしりとりできない...'
+        end
+
         word = words[message.body[-1]]
         return message.reply 'えーひらがなで言ってくれないとわかんない...' unless word
 

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -27,7 +27,7 @@ class ShiritoriTest < Minitest::Test
     end
   end
 
-  def test_shiritori_should_return_argument_error_rack_word
+  def test_shiritori_should_return_argument_error_lack_word
     %w[shiritori しりとり].each do |command|
       @said = "@ruboty #{command}"
       assert_output(/^なんか言ってくれないとしりとりできない...$/) { @bot.receive body: @said, from: @from, to: @to }

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -26,4 +26,11 @@ class ShiritoriTest < Minitest::Test
       assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
     end
   end
+
+  def test_shiritori_should_return_argument_error_rack_word
+    %w[shiritori しりとり].each do |command|
+      @said = "@ruboty #{command}"
+      assert_output(/^なんか言ってくれないとしりとりできない...$/) { @bot.receive body: @said, from: @from, to: @to }
+    end
+  end
 end


### PR DESCRIPTION
現状の動きとして、`riety shiritori`とコマンドすると`i`を入力したと判断するため、対象ワードがないときはメッセージを表示するようにしました。
