### PR TITLE
コマンドに余計な文字がくっついているときは無視させるようにする

### DIFF
--- a/lib/riety/handlers/celebrate.rb
+++ b/lib/riety/handlers/celebrate.rb
@@ -1,10 +1,10 @@
 module Riety
   module Handlers
     class Celebrate < Ruboty::Handlers::Base
-      on /(celebrate|お祝い)\s.+\z/, name: 'celebrate', description: "みんなからのお祝い(例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
+      on /(celebrate|お祝い)((\s|　)+(?<keyword>.+))?\z/, name: 'celebrate', description: "みんなからのお祝い(例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
 
       def celebrate(message)
-        name = message.body.split(' ')[2]
+        name = message[:keyword]
         return message.reply '名前を指定してください＼(^o^)／' unless name
         return message.reply member_list if name == 'list'
 

--- a/lib/riety/handlers/celebrate.rb
+++ b/lib/riety/handlers/celebrate.rb
@@ -1,7 +1,7 @@
 module Riety
   module Handlers
     class Celebrate < Ruboty::Handlers::Base
-      on /celebrate|お祝い/, name: 'celebrate', description: "みんなからのお祝い(例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
+      on /(celebrate|お祝い)\s.+\z/, name: 'celebrate', description: "みんなからのお祝い(例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
 
       def celebrate(message)
         name = message.body.split(' ')[2]

--- a/lib/riety/handlers/extreme_wedding.rb
+++ b/lib/riety/handlers/extreme_wedding.rb
@@ -1,7 +1,7 @@
 module Riety
   module Handlers
     class ExtremeWedding < Ruboty::Handlers::Base
-      on /extreme wedding/, name: 'extreme_wedding', description: 'Never ending spiral'
+      on /extreme wedding\z/, name: 'extreme_wedding', description: 'Never ending spiral'
 
       def extreme_wedding(message)
         res =<<-EOF

--- a/lib/riety/handlers/group_photo.rb
+++ b/lib/riety/handlers/group_photo.rb
@@ -1,7 +1,7 @@
 module Riety
   module Handlers
     class GroupPhoto < Ruboty::Handlers::Base
-      on /group photo/, name: 'group_photo', description: 'Display group photo at random'
+      on /group photo\z/, name: 'group_photo', description: 'Display group photo at random'
 
       def group_photo(message)
         message.reply photo_urls.sample

--- a/lib/riety/handlers/hello.rb
+++ b/lib/riety/handlers/hello.rb
@@ -1,7 +1,7 @@
 module Riety
   module Handlers
     class Hello < Ruboty::Handlers::Base
-      on /hello/, name: 'hello', description: 'greet'
+      on /hello\z/, name: 'hello', description: 'greet'
 
       def hello(message)
         message.reply 'Hi'

--- a/lib/riety/handlers/shiritori.rb
+++ b/lib/riety/handlers/shiritori.rb
@@ -3,7 +3,7 @@ require 'yaml'
 module Riety
   module Handlers
     class Shiritori < Ruboty::Handlers::Base
-      on /shiritori|しりとり/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
+      on /(shiritori|しりとり)\s.+\z/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
 
       def shiritori(message)
         if message.body.split(/\s|　/).count == 2

--- a/lib/riety/handlers/shiritori.rb
+++ b/lib/riety/handlers/shiritori.rb
@@ -3,14 +3,12 @@ require 'yaml'
 module Riety
   module Handlers
     class Shiritori < Ruboty::Handlers::Base
-      on /(shiritori|しりとり)\s.+\z/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
+      on /(shiritori|しりとり)((\s|　)+(?<keyword>.+))?\z/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
 
       def shiritori(message)
-        if message.body.split(/\s|　/).count == 2
-          return message.reply 'なんか言ってくれないとしりとりできない...'
-        end
+        return message.reply 'なんか言ってくれないとしりとりできない...' unless message[:keyword]
 
-        word = words[message.body[-1]]
+        word = words[message[:keyword][-1]]
         return message.reply 'えーひらがなで言ってくれないとわかんない...' unless word
 
         if word.is_a? Array

--- a/test/handlers/test_celebrate.rb
+++ b/test/handlers/test_celebrate.rb
@@ -2,9 +2,7 @@ require './test/test_helper.rb'
 
 class CelebrateTest < Minitest::Test
   def setup
-    @bot = ::Ruboty::Robot.new
-    @to = '#general'
-    @from = 'alice'
+    super
   end
 
   def test_celebrate_should_return_message_by_name

--- a/test/handlers/test_celebrate.rb
+++ b/test/handlers/test_celebrate.rb
@@ -6,12 +6,12 @@ class CelebrateTest < Minitest::Test
   end
 
   def test_celebrate_should_return_message_by_name
-    said = '@ruboty celebrate サンプル'
+    said = '@riety celebrate サンプル'
     assert_output(/^おめでとう$/) { @bot.receive body: said, from: @from, to: @to }
   end
 
   def test_celebrate_should_return_member_list
-    said = '@ruboty celebrate list'
+    said = '@riety celebrate list'
     assert_output(/^サンプル/) { @bot.receive body: said, from: @from, to: @to }
   end
 end

--- a/test/handlers/test_extreme_wedding.rb
+++ b/test/handlers/test_extreme_wedding.rb
@@ -4,7 +4,7 @@ require 'byebug'
 class ExtremeWeddingTest < Minitest::Test
   def setup
     super
-    @said = '@ruboty extreme wedding'
+    @said = '@riety extreme wedding'
   end
 
   def test_extreme_wedding

--- a/test/handlers/test_extreme_wedding.rb
+++ b/test/handlers/test_extreme_wedding.rb
@@ -3,9 +3,7 @@ require 'byebug'
 
 class ExtremeWeddingTest < Minitest::Test
   def setup
-    @bot = ::Ruboty::Robot.new
-    @to = '#general'
-    @from = 'alice'
+    super
     @said = '@ruboty extreme wedding'
   end
 

--- a/test/handlers/test_group_photo.rb
+++ b/test/handlers/test_group_photo.rb
@@ -3,7 +3,7 @@ require './test/test_helper'
 class GroupPhotoTest < Minitest::Test
   def setup
     super
-    @said = '@ruboty group photo'
+    @said = '@riety group photo'
   end
 
   def test_gruop_photo_return_image_url

--- a/test/handlers/test_group_photo.rb
+++ b/test/handlers/test_group_photo.rb
@@ -2,9 +2,7 @@ require './test/test_helper'
 
 class GroupPhotoTest < Minitest::Test
   def setup
-    @bot = ::Ruboty::Robot.new
-    @to = '#general'
-    @from = 'alice'
+    super
     @said = '@ruboty group photo'
   end
 

--- a/test/handlers/test_hello.rb
+++ b/test/handlers/test_hello.rb
@@ -2,9 +2,7 @@ require './test/test_helper'
 
 class HelloTest < Minitest::Test
   def setup
-    @bot = ::Ruboty::Robot.new
-    @to = '#general'
-    @from = 'alice'
+    super
     @said = '@ruboty hello'
   end
 

--- a/test/handlers/test_hello.rb
+++ b/test/handlers/test_hello.rb
@@ -3,7 +3,7 @@ require './test/test_helper'
 class HelloTest < Minitest::Test
   def setup
     super
-    @said = '@ruboty hello'
+    @said = '@riety hello'
   end
 
   def test_hello

--- a/test/handlers/test_nice_to_meet_you.rb
+++ b/test/handlers/test_nice_to_meet_you.rb
@@ -2,10 +2,12 @@ require './test/test_helper'
 
 class NiceToMeetYouTest < Minitest::Test
   def setup
-    @bot = ::Ruboty::Robot.new
-    @to = '#general'
-    @from = 'alice'
+    super
     @said = 'hi'
+  end
+
+  def after_setup
+    @bot.brain.data[:customers] = []
   end
 
   def test_nice_to_meet_you

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -33,4 +33,12 @@ class ShiritoriTest < Minitest::Test
       assert_output(/^なんか言ってくれないとしりとりできない...$/) { @bot.receive body: @said, from: @from, to: @to }
     end
   end
+
+  def test_shiritori_should_not_allow_to_contain_invalid_characters
+    %w(shiritori しりとり).each do |command|
+      assert_silent { @bot.receive body: "@ruboty #{command}あ はにわ", from: @from, to: @to }
+
+      assert_silent { @bot.receive body: "@ruboty あ#{command} はにわ", from: @from, to: @to }
+    end
+  end
 end

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -33,16 +33,16 @@ class ShiritoriTest < Minitest::Test
 
   def test_shiritori_should_return_argument_error_lack_word
     %w[shiritori しりとり].each do |command|
-      @said = "@ruboty #{command}"
+      @said = "@riety #{command}"
       assert_output(/^なんか言ってくれないとしりとりできない...$/) { @bot.receive body: @said, from: @from, to: @to }
     end
   end
 
   def test_shiritori_should_not_allow_to_contain_invalid_characters
     %w(shiritori しりとり).each do |command|
-      assert_silent { @bot.receive body: "@ruboty #{command}あ はにわ", from: @from, to: @to }
+      assert_silent { @bot.receive body: "@riety #{command}あ はにわ", from: @from, to: @to }
 
-      assert_silent { @bot.receive body: "@ruboty あ#{command} はにわ", from: @from, to: @to }
+      assert_silent { @bot.receive body: "@riety あ#{command} はにわ", from: @from, to: @to }
     end
   end
 end

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -16,6 +16,12 @@ class ShiritoriTest < Minitest::Test
     end
   end
 
+  def test_shiritori_executes_with_the_last_word_given
+    %w(shiritori しりとり).each do |command|
+      assert_output(/^ワッペン$/) { @bot.receive body: "@riety #{command} ちーず まめだいふく えいわ", from: @from, to: @to }
+    end
+  end
+
   def test_shiritori_cannot_understand_non_hiragana_word
     %w[shiritori しりとり].each do |command|
       @said = "@ruboty #{command} ...a"

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -7,9 +7,9 @@ class ShiritoriTest < Minitest::Test
 
   def test_shiritori_should_return_expected_reply_which_ends_shiritori
     %w[shiritori しりとり].each do |command|
-      @said = "@ruboty #{command} ...あ"
+      @said = "@riety #{command} ...あ"
       assert_output(/^アサーション$/) { @bot.receive body: @said, from: @from, to: @to }
-      @said = "@ruboty #{command} ...わ"
+      @said = "@riety #{command} ...わ"
       assert_output(/^ワッペン$/) { @bot.receive body: @said, from: @from, to: @to }
     end
   end
@@ -22,11 +22,11 @@ class ShiritoriTest < Minitest::Test
 
   def test_shiritori_cannot_understand_non_hiragana_word
     %w[shiritori しりとり].each do |command|
-      @said = "@ruboty #{command} ...a"
+      @said = "@riety #{command} ...a"
       assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
-      @said = "@ruboty #{command} ...1"
+      @said = "@riety #{command} ...1"
       assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
-      @said = "@ruboty #{command} ...亜"
+      @said = "@riety #{command} ...亜"
       assert_output(/^えーひらがなで言ってくれないとわかんない...$/) { @bot.receive body: @said, from: @from, to: @to }
     end
   end

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -2,9 +2,7 @@ require './test/test_helper'
 
 class ShiritoriTest < Minitest::Test
   def setup
-    @bot = ::Ruboty::Robot.new
-    @to = '#general'
-    @from = 'alice'
+    super
   end
 
   def test_shiritori_should_return_expected_reply_which_ends_shiritori

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,17 @@ require 'byebug'
 require 'ruboty'
 require 'fakeredis'
 require './init'
+
+module Riety
+  module Test
+    def setup
+      super
+      @bot = ::Ruboty::Robot.new
+      @from = 'alice'
+      @to = '#general'
+      @bot.brain.data[:customers] = [@from]
+    end
+
+    ::Minitest::Test.send(:prepend, self)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,11 @@
 require 'minitest/autorun'
 require 'byebug'
 require 'ruboty'
+require 'ruboty/redis'
 require 'fakeredis'
 require './init'
+
+Dotenv.load
 
 module Riety
   module Test


### PR DESCRIPTION
# 概要

現状の実装だと、たとえば `shiritori` コマンドの場合、`riety shiritoriあいうえお あああ` というように「コマンドに余計な文字がくっついている」場合でも、期待したコマンドとして認識されるようになっています。
これを、正しい文字列のコマンドを入力されたときのみ認識されるようにします。
# TODO
- [x] テストを書く
- [x] 既存のコマンドに対応する（正規表現の修正）
