### PR TITLE
shiritoriとcelebrateの単語に続く空白を考慮  [closes #31, closes #32]

### DIFF
--- a/lib/riety/handlers/celebrate.rb
+++ b/lib/riety/handlers/celebrate.rb
@@ -1,7 +1,7 @@
 module Riety
   module Handlers
     class Celebrate < Ruboty::Handlers::Base
-      on /(celebrate|お祝い)((\s|　)+(?<keyword>.+))?\z/, name: 'celebrate', description: "みんなからのお祝い(例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
+      on /(celebrate|お祝い)((\s|　)+|((\s|　)+(?<keyword>.+)))?\z/, name: 'celebrate', description: "みんなからのお祝い(例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
 
       def celebrate(message)
         name = message[:keyword]

--- a/lib/riety/handlers/shiritori.rb
+++ b/lib/riety/handlers/shiritori.rb
@@ -3,7 +3,7 @@ require 'yaml'
 module Riety
   module Handlers
     class Shiritori < Ruboty::Handlers::Base
-      on /(shiritori|しりとり)((\s|　)+(?<keyword>.+))?\z/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
+      on /(shiritori|しりとり)((\s|　)+|((\s|　)+(?<keyword>.+)))?\z/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
 
       def shiritori(message)
         return message.reply 'なんか言ってくれないとしりとりできない...' unless message[:keyword]

--- a/test/handlers/test_celebrate.rb
+++ b/test/handlers/test_celebrate.rb
@@ -14,4 +14,32 @@ class CelebrateTest < Minitest::Test
     said = '@riety celebrate list'
     assert_output(/^サンプル/) { @bot.receive body: said, from: @from, to: @to }
   end
+
+  def test_celebrate_should_return_error_when_no_name_is_given
+    %w[celebrate お祝い].each do |command|
+      said = "@riety #{command}"
+      assert_output(/^名前を指定してください/) { @bot.receive body: said, from: @from, to: @to }
+    end
+  end
+
+  def test_celebrate_should_return_error_when_only_single_space_is_given
+    %w[celebrate お祝い].each do |command|
+      said = "@riety #{command} "
+      assert_output(/^名前を指定してください/) { @bot.receive body: said, from: @from, to: @to }
+    end
+  end
+
+  def test_celebrate_should_return_error_when_only_continuous_spaces_are_given
+    %w[celebrate お祝い].each do |command|
+      said = "@riety #{command}  　 "
+      assert_output(/^名前を指定してください/) { @bot.receive body: said, from: @from, to: @to }
+    end
+  end
+
+  def test_celebrate_should_return_message_when_name_with_leading_spaces_are_given
+    %w[celebrate お祝い].each do |command|
+      said = "@riety #{command}  　 サンプル"
+      assert_output(/^おめでとう$/) { @bot.receive body: said, from: @from, to: @to }
+    end
+  end
 end

--- a/test/handlers/test_shiritori.rb
+++ b/test/handlers/test_shiritori.rb
@@ -45,4 +45,25 @@ class ShiritoriTest < Minitest::Test
       assert_silent { @bot.receive body: "@riety あ#{command} はにわ", from: @from, to: @to }
     end
   end
+
+  def test_shiritori_should_return_error_when_only_single_space_is_given
+    %w(shiritori しりとり).each do |command|
+      @said = "@riety #{command} "
+      assert_output(/^なんか言ってくれないとしりとりできない...$/) { @bot.receive body: @said, from: @from, to: @to }
+    end
+  end
+
+  def test_shiritori_should_return_error_when_only_continuous_spaces_are_given
+    %w(shiritori しりとり).each do |command|
+      @said = "@riety #{command}  　 "
+      assert_output(/^なんか言ってくれないとしりとりできない...$/) { @bot.receive body: @said, from: @from, to: @to }
+    end
+  end
+
+  def test_shiritori_should_return_expected_word_when_keyword_with_leading_spaces_are_given
+    %w(shiritori しりとり).each do |command|
+      @said = "@riety #{command}  　 こんにちわ"
+      assert_output(/^ワッペン$/) { @bot.receive body: @said, from: @from, to: @to }
+    end
+  end
 end


### PR DESCRIPTION
#31 と #32 に対応しました。
