### PR TITLE
ヘルプメッセージを見やすくした

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -3,3 +3,4 @@ Bundler.require(:default, :production) if ENV['IDOBATA_API_TOKEN']
 $LOAD_PATH.unshift File.dirname(__FILE__)
 Dir["lib/riety/handlers/*.rb"].each { |file| require file }
 Dir["lib/riety/actions/*.rb"].each { |file| require file }
+Dir["lib/riety/ext/*.rb"].each { |file| require file }

--- a/lib/riety/ext/help_prettifier.rb
+++ b/lib/riety/ext/help_prettifier.rb
@@ -12,8 +12,7 @@ module Riety
       _descriptions = Ruboty.actions.reject(&:hidden?).sort.map do |action|
         prefix = ""
         prefix << message.robot.name << " " unless  action.all?
-        command = action.command
-        "#{prefix}#{command || action.pattern.inspect} - #{action.description}"
+        "#{prefix}#{action.command || action.pattern.inspect} - #{action.description}"
       end
     end
   end

--- a/lib/riety/ext/help_prettifier.rb
+++ b/lib/riety/ext/help_prettifier.rb
@@ -1,0 +1,30 @@
+module Riety
+  # Patches all_description method of Ruboty::Actions::Help
+  # to avoid help messages get messed up
+  #
+  # Help message will show 'command' option in place of inspected pattern
+  # when provided.
+  module HelpPrettifier
+
+    private
+
+    def all_descriptions
+      _descriptions = Ruboty.actions.reject(&:hidden?).sort.map do |action|
+        prefix = ""
+        prefix << message.robot.name << " " unless  action.all?
+        command = action.command
+        "#{prefix}#{command || action.pattern.inspect} - #{action.description}"
+      end
+    end
+  end
+
+  # Adds 'command' option to Ruboty::Action
+  module CommandAttrAdder
+    def command
+      options[:command]
+    end
+  end
+
+  ::Ruboty::Actions::Help.send(:prepend, HelpPrettifier)
+  ::Ruboty::Action.send(:include, CommandAttrAdder)
+end

--- a/lib/riety/handlers/celebrate.rb
+++ b/lib/riety/handlers/celebrate.rb
@@ -1,7 +1,12 @@
 module Riety
   module Handlers
     class Celebrate < Ruboty::Handlers::Base
-      on /(celebrate|お祝い)((\s|　)+|((\s|　)+(?<keyword>.+)))?\z/, name: 'celebrate', description: "みんなからのお祝い(例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
+      on(
+        /(celebrate|お祝い)((\s|　)+|((\s|　)+(?<keyword>.+)))?\z/,
+        name: 'celebrate',
+        command: 'celebrate(or お祝い) 名前',
+        description: "みんなからのお祝い (例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
+      )
 
       def celebrate(message)
         name = message[:keyword]

--- a/lib/riety/handlers/extreme_wedding.rb
+++ b/lib/riety/handlers/extreme_wedding.rb
@@ -1,7 +1,12 @@
 module Riety
   module Handlers
     class ExtremeWedding < Ruboty::Handlers::Base
-      on /extreme wedding\z/, name: 'extreme_wedding', description: 'Never ending spiral'
+      on(
+        /extreme wedding\z/,
+        name: 'extreme_wedding',
+        command: 'extreme wedding',
+        description: 'Never ending spiral'
+      )
 
       def extreme_wedding(message)
         res =<<-EOF

--- a/lib/riety/handlers/group_photo.rb
+++ b/lib/riety/handlers/group_photo.rb
@@ -1,7 +1,12 @@
 module Riety
   module Handlers
     class GroupPhoto < Ruboty::Handlers::Base
-      on /group photo\z/, name: 'group_photo', description: 'Display group photo at random'
+      on(
+        /group photo\z/,
+        name: 'group_photo',
+        command: 'group_photo',
+        description: 'Display group photo at random'
+      )
 
       def group_photo(message)
         message.reply photo_urls.sample

--- a/lib/riety/handlers/nice_to_meet_you.rb
+++ b/lib/riety/handlers/nice_to_meet_you.rb
@@ -1,7 +1,12 @@
 module Riety
   module Handlers
     class NiceToMeetYou < Ruboty::Handlers::Base
-      on //, all: true, name: 'nice_to_meet_you', description: 'Welcome message'
+      on(
+        //,
+        all: true,
+        name: 'nice_to_meet_you',
+        description: 'Welcome message',
+      )
 
       def nice_to_meet_you(message)
         Riety::Actions::NiceToMeetYou.new(message).call

--- a/lib/riety/handlers/nice_to_meet_you.rb
+++ b/lib/riety/handlers/nice_to_meet_you.rb
@@ -6,6 +6,7 @@ module Riety
         all: true,
         name: 'nice_to_meet_you',
         description: 'Welcome message',
+        hidden: true
       )
 
       def nice_to_meet_you(message)

--- a/lib/riety/handlers/shiritori.rb
+++ b/lib/riety/handlers/shiritori.rb
@@ -3,7 +3,12 @@ require 'yaml'
 module Riety
   module Handlers
     class Shiritori < Ruboty::Handlers::Base
-      on /(shiritori|しりとり)((\s|　)+|((\s|　)+(?<keyword>.+)))?\z/, name: 'shiritori', description: "しりとり (例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
+      on(
+        /(shiritori|しりとり)((\s|　)+|((\s|　)+(?<keyword>.+)))?\z/,
+        name: 'shiritori',
+        command: "shiritori(or しりとり) 言葉",
+        description: "(例: @#{ENV['ROBOT_NAME']} shiritori うみほたる、@#{ENV['ROBOT_NAME']} しりとり はんばーぐ)"
+      )
 
       def shiritori(message)
         return message.reply 'なんか言ってくれないとしりとりできない...' unless message[:keyword]

--- a/test/handlers/test_help.rb
+++ b/test/handlers/test_help.rb
@@ -1,0 +1,15 @@
+require './test/test_helper.rb'
+
+class HelpTest < Minitest::Test
+  def setup
+    super
+  end
+
+  def test_help_should_returns_original_pattern_when_command_is_not_provided
+    assert_output(/riety \/hello\\z\/ - greet/) { @bot.receive body: '@riety help', from: @from, to: @to }
+  end
+
+  def test_help_should_returns_command_text_when_it_is_provided
+    assert_output(/riety extreme wedding - Never ending spiral/) { @bot.receive body: '@riety help', from: @from, to: @to }
+  end
+end


### PR DESCRIPTION
botに話しかける人として、
ヘルプメッセージは見やすいものであってほしい。
なぜなら、ぶっちゃけ読めないからだ。

正規表現が複雑になってヘルプメッセージがだいぶハードコアな感じになっていたので、
強引にですが少しでも見やすくなるようにする改修を行いました。
### before

<img width="798" alt="2015-12-02 23 08 36" src="https://cloud.githubusercontent.com/assets/333180/11532874/17d5ca64-994a-11e5-9c82-ad444ae35c18.png">
### after

<img width="791" alt="2015-12-02 23 08 48" src="https://cloud.githubusercontent.com/assets/333180/11532886/273952aa-994a-11e5-9865-4086c78672dc.png">
### 使いかた

`on` メソッドに `command` オプションを渡すと、それが渡された場合だけ正規表現パターンそのままではなく `command` に渡された文字列を表示するようになります。

Ruboty のコアクラスにパッチしているし完全にオリジナル機能なので微妙な実装ですが、正直、具体例があるとはいえ、あのヘルプだと初めて見る人は把握するのが結構大変な気がして…
