### PR TITLE
herokuで celebrate listでメッセージを登録したメンバーの一覧を表示できる

### DIFF
--- a/lib/riety/handlers/celebrate.rb
+++ b/lib/riety/handlers/celebrate.rb
@@ -23,7 +23,7 @@ module Riety
 
       private
         def member_list
-          YAML.load_file(file_path).keys
+          YAML.load_file(file_path).keys.join("\n")
         end
 
         def massage_from(who: )


### PR DESCRIPTION
herokuでうまく動いてなかったので直しました。
