### PR TITLE
全員からのメッセージを順番に表示する

### DIFF
--- a/lib/riety/handlers/celebrate.rb
+++ b/lib/riety/handlers/celebrate.rb
@@ -22,13 +22,19 @@ module Riety
       end
 
       private
+
+        def messages
+          @messages ||= YAML.load_file(file_path)
+        end
+
         def member_list
-          YAML.load_file(file_path).keys.join("\n")
+          messages.keys.join("\n")
         end
 
         def massage_from(who: )
-          @messages ||= YAML.load_file(file_path)
-          @messages[who]
+          messages[who]
+        end
+
         end
 
         def file_path

--- a/lib/riety/handlers/celebrate.rb
+++ b/lib/riety/handlers/celebrate.rb
@@ -4,13 +4,18 @@ module Riety
       on(
         /(celebrate|お祝い)((\s|　)+|((\s|　)+(?<keyword>.+)))?\z/,
         name: 'celebrate',
-        command: 'celebrate(or お祝い) 名前',
-        description: "みんなからのお祝い (例: @#{ENV['ROBOT_NAME']} celebrate きたむら) | 名簿を見たかったら list オプション"
+        command: 'celebrate(or お祝い)',
+        description: "みんなからのお祝い | 名簿を見るには (@#{ENV['ROBOT_NAME']} celebrate list) | 個別メッセージは (@#{ENV['ROBOT_NAME']} celebrate 名前)"
       )
 
       def celebrate(message)
         name = message[:keyword]
-        return message.reply '名前を指定してください＼(^o^)／' unless name
+        unless name
+          all_messages do |msg|
+            message.reply msg
+          end
+          return
+        end
         return message.reply member_list if name == 'list'
 
         msg = massage_from(who: name)
@@ -35,6 +40,25 @@ module Riety
           messages[who]
         end
 
+        def all_messages
+          yield <<-EOS
+#{':rose:' * 13}  
+:memo:&nbsp;__yochiyochi.rb celebration messages!__  
+#{':rose:' * 13}
+          EOS
+          wait_a_bit
+          messages.each do |message|
+            next if message[0] == "サンプル"
+            yield <<-EOS
+:love_letter:&nbsp;__A message from #{message[0]}__
+#{message[1]}
+            EOS
+            wait_a_bit
+          end
+        end
+
+        def wait_a_bit
+          sleep 1.5
         end
 
         def file_path

--- a/test/handlers/test_celebrate.rb
+++ b/test/handlers/test_celebrate.rb
@@ -6,6 +6,38 @@ class CelebrateTest < Minitest::Test
     @commands = %w(celebrate お祝い)
   end
 
+  def test_celebrate_with_no_arguments_should_reply_header_message
+    Riety::Handlers::Celebrate.stub_any_instance(:wait_a_bit, wait_a_bit) do
+      @commands.each do |command|
+        assert_output(/^.+yochiyochi.rb celebration messages!.+$/) { @bot.receive body: "@riety #{command}", from: @from, to: @to }
+      end
+    end
+  end
+
+  def test_celebrate_with_no_arguments_should_reply_all_messages
+    Riety::Handlers::Celebrate.stub_any_instance(:wait_a_bit, wait_a_bit) do
+      @commands.each do |command|
+        assert_output(/^.+きたむら.+おがさわら.+$/m) { @bot.receive body: "@riety #{command}", from: @from, to: @to }
+      end
+    end
+  end
+
+  def test_celebrate_should_reply_messages_when_only_single_space_is_given
+    Riety::Handlers::Celebrate.stub_any_instance(:wait_a_bit, wait_a_bit) do
+      @commands.each do |command|
+        assert_output(/^.+きたむら.+おがさわら.+$/m) { @bot.receive body: "@riety #{command} ", from: @from, to: @to }
+      end
+    end
+  end
+
+  def test_celebrate_should_return_error_when_only_continuous_spaces_are_given
+    Riety::Handlers::Celebrate.stub_any_instance(:wait_a_bit, wait_a_bit) do
+      @commands.each do |command|
+        assert_output(/^.+きたむら.+おがさわら.+$/m) { @bot.receive body: "@riety #{command}  　 ", from: @from, to: @to }
+      end
+    end
+  end
+
   def test_celebrate_should_return_message_by_name
     @commands.each do |command|
       assert_output(/^おめでとう$/) { @bot.receive body: "@riety #{command} サンプル", from: @from, to: @to }
@@ -18,27 +50,15 @@ class CelebrateTest < Minitest::Test
     end
   end
 
-  def test_celebrate_should_return_error_when_no_name_is_given
-    @commands.each do |command|
-      assert_output(/^名前を指定してください/) { @bot.receive body: "@riety #{command}", from: @from, to: @to }
-    end
-  end
-
-  def test_celebrate_should_return_error_when_only_single_space_is_given
-    @commands.each do |command|
-      assert_output(/^名前を指定してください/) { @bot.receive body: "@riety #{command} ", from: @from, to: @to }
-    end
-  end
-
-  def test_celebrate_should_return_error_when_only_continuous_spaces_are_given
-    @commands.each do |command|
-      assert_output(/^名前を指定してください/) { @bot.receive body: "@riety #{command}  　 ", from: @from, to: @to }
-    end
-  end
-
   def test_celebrate_should_return_message_when_name_with_leading_spaces_are_given
     @commands.each do |command|
       assert_output(/^おめでとう$/) { @bot.receive body: "@riety #{command}  　 サンプル", from: @from, to: @to }
     end
   end
+
+  private
+
+    def wait_a_bit
+      # do nothing
+    end
 end


### PR DESCRIPTION
WIP消しました。
- 引数なしで celebrate を実行すると、みんなからのメッセージを順番に表示する
- 次のメッセージは1.5秒待ってから表示 (できるだけ短くしたいけど1秒は短すぎるのでギリギリこれ)

<img width="754" alt="2015-12-10 0 01 05" src="https://cloud.githubusercontent.com/assets/333180/11688702/7bde90ea-9ed1-11e5-9ec2-86c0299bba8c.png">
