### PR TITLE
アイコン画像を大きく表示するコマンドを追加

### DIFF
--- a/lib/riety/handlers/portrait.rb
+++ b/lib/riety/handlers/portrait.rb
@@ -1,0 +1,20 @@
+module Riety
+  module Handlers
+    class Portrait < Ruboty::Handlers::Base
+      on(
+        /portrait(\s|　)*\z/,
+        name: 'portrait',
+        command: 'portrait',
+        description: 'Display a large size portrait'
+      )
+
+      def portrait(message)
+        image_url = "https://s3-ap-northeast-1.amazonaws.com/llio-pub/masakari-chance.png"
+        message.reply <<-EOS
+![portrait](#{image_url})"
+by __yucao24hours__ :gift_heart:
+        EOS
+      end
+    end
+  end
+end

--- a/lib/riety/handlers/portrait.rb
+++ b/lib/riety/handlers/portrait.rb
@@ -11,7 +11,7 @@ module Riety
       def portrait(message)
         image_url = "https://s3-ap-northeast-1.amazonaws.com/llio-pub/rie_icon_large.jpg"
         message.reply <<-EOS
-![portrait](#{image_url})"
+![portrait](#{image_url})
 by __yucao24hours__ :gift_heart:
         EOS
       end

--- a/lib/riety/handlers/portrait.rb
+++ b/lib/riety/handlers/portrait.rb
@@ -9,7 +9,7 @@ module Riety
       )
 
       def portrait(message)
-        image_url = "https://s3-ap-northeast-1.amazonaws.com/llio-pub/masakari-chance.png"
+        image_url = "https://s3-ap-northeast-1.amazonaws.com/llio-pub/rie_icon_large.jpg"
         message.reply <<-EOS
 ![portrait](#{image_url})"
 by __yucao24hours__ :gift_heart:

--- a/test/handlers/test_portrait.rb
+++ b/test/handlers/test_portrait.rb
@@ -1,0 +1,23 @@
+require './test/test_helper'
+
+class PortraitTest < Minitest::Test
+  def setup
+    @expected = %r{\A#{Regexp.escape('![portrait](http')}s?://.+(jpg|jpeg|png)\).+yucao.+\Z}im
+    super
+  end
+
+  def test_portrait_should_reply_embedded_portrait_image
+    assert_output(@expected) { @bot.receive body: "@riety portrait", from: @from, to: @to }
+  end
+
+  def test_portrait_should_reply_embedded_portrait_image_when_with_trailing_whitespaces
+    assert_output(@expected) { @bot.receive body: "@riety portrait  　　 ", from: @from, to: @to }
+  end
+
+  def test_portrait_should_not_allow_trailing_invalid_characters
+    assert_silent { @bot.receive body: "@riety portraitX", from: @from, to: @to }
+    assert_silent { @bot.receive body: "@riety portraitXXX", from: @from, to: @to }
+    assert_silent { @bot.receive body: "@riety portrait XXX", from: @from, to: @to }
+    assert_silent { @bot.receive body: "@riety portrait 　 　XXX", from: @from, to: @to }
+  end
+end


### PR DESCRIPTION
> idobata って、アイコン画像を大きくして見えるビューがないんだよなあ。Slack だったらプロフィールページとかあるけど
> その画像を出すためのコマンド実装する、とかかな やるとしたら

アイコン画像を大きく表示するコマンドを追加しました。まだ画像を持っていないので仮の画像です。
- [x] コマンド名は何がいい？ (今は `portrait`)
- [x] 画像はどこにおく？ (とりあえず自分のS3のつもりです。idobataはいつまで保存してくれるのか知らないから)
- [x] 画像を本物に差し替える

<img width="782" alt="2015-12-10 13 42 19" src="https://cloud.githubusercontent.com/assets/333180/11707263/582caac8-9f45-11e5-856c-66fe6f39b9b7.png">

特に突っ込みがなければ、画像が準備でき次第、今の仕様でマージしようかなと思ってます。
